### PR TITLE
Remove restriction on Details suffix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.publicuhc</groupId>
     <artifactId>pluginframework</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
 
     <properties>
         <bukkit.version>LATEST</bukkit.version>

--- a/src/main/java/com/publicuhc/pluginframework/commands/routing/DefaultRouter.java
+++ b/src/main/java/com/publicuhc/pluginframework/commands/routing/DefaultRouter.java
@@ -82,8 +82,6 @@ public class DefaultRouter implements Router {
 
     private final Logger m_logger;
 
-    private static final String ROUTE_INFO_SUFFIX = "Details";
-
     @Inject
     protected DefaultRouter(Provider<CommandRequestBuilder> requestProvider, Injector injector, PluginLogger logger, MethodChecker checker) {
         m_requestProvider = requestProvider;
@@ -128,9 +126,9 @@ public class DefaultRouter implements Router {
             //get the method with the details we need
             Method routeInfo;
             try {
-                routeInfo = klass.getMethod(method.getName() + ROUTE_INFO_SUFFIX, RouteBuilder.class);
+                routeInfo = klass.getMethod(method.getName(), RouteBuilder.class);
             } catch (NoSuchMethodException e) {
-                m_logger.log(Level.SEVERE, "No method found with the name " + method.getName() + ROUTE_INFO_SUFFIX);
+                m_logger.log(Level.SEVERE, "No method found with the name " + method.getName());
                 throw new DetailsMethodNotFoundException();
             }
 

--- a/src/test/java/com/publicuhc/pluginframework/commands/routing/testcommands/TestExceptionCommandMethod.java
+++ b/src/test/java/com/publicuhc/pluginframework/commands/routing/testcommands/TestExceptionCommandMethod.java
@@ -37,7 +37,7 @@ public class TestExceptionCommandMethod {
     }
 
     @RouteInfo
-    public void exceptionDetails(RouteBuilder builder) {
+    public void exception(RouteBuilder builder) {
         builder.restrictCommand("test");
     }
 
@@ -47,7 +47,7 @@ public class TestExceptionCommandMethod {
     }
 
     @RouteInfo
-    public void tabexceptionDetails(RouteBuilder builder) {
+    public void tabexception(RouteBuilder builder) {
         builder.restrictCommand("test");
     }
 }

--- a/src/test/java/com/publicuhc/pluginframework/commands/routing/testcommands/TestFullCommands.java
+++ b/src/test/java/com/publicuhc/pluginframework/commands/routing/testcommands/TestFullCommands.java
@@ -41,7 +41,7 @@ public class TestFullCommands {
     }
 
     @RouteInfo
-    public void banIPDetails(RouteBuilder builder) {
+    public void banIP(RouteBuilder builder) {
         builder.restrictCommand("banIP")
                 .restrictPermission("test.permission")
                 .restrictPattern(Pattern.compile("^([\\d]{1,3}.[\\d]{1,3}.[\\d]{1,3}.[\\d]{1,3}) (.*)$"));
@@ -57,7 +57,7 @@ public class TestFullCommands {
     }
 
     @RouteInfo
-    public void completeDetails(RouteBuilder builder) {
+    public void complete(RouteBuilder builder) {
         builder.restrictCommand("banIP")
                 .restrictPattern(Pattern.compile("^([\\d]{1,3}.[\\d]{1,3}.[\\d]{1,3}.[\\d]{1,3})$"))
                 .restrictPermission("test.permission");

--- a/src/test/java/com/publicuhc/pluginframework/commands/routing/testcommands/TestMissingBaseCommands.java
+++ b/src/test/java/com/publicuhc/pluginframework/commands/routing/testcommands/TestMissingBaseCommands.java
@@ -34,7 +34,7 @@ public class TestMissingBaseCommands {
     }
 
     @RouteInfo
-    public void commandMissingDetails(RouteBuilder builder) {
+    public void commandMissing(RouteBuilder builder) {
         builder.restrictCommand("unknowncommand");
     }
 }

--- a/src/test/java/com/publicuhc/pluginframework/commands/routing/testcommands/TestValidCommands.java
+++ b/src/test/java/com/publicuhc/pluginframework/commands/routing/testcommands/TestValidCommands.java
@@ -41,12 +41,12 @@ public class TestValidCommands {
     }
 
     @RouteInfo
-    public void testCommandDetails(RouteBuilder builder) {
+    public void testCommand(RouteBuilder builder) {
         builder.restrictCommand("test");
     }
 
     @RouteInfo
-    public void testTabCompleteDetails(RouteBuilder builder) {
+    public void testTabComplete(RouteBuilder builder) {
         builder.restrictCommand("test");
     }
 }


### PR DESCRIPTION
All @RouteInfo annotations require the method to have the suffix 'Details'. This removes the restriction seeing as the method signatures are different
