### PR TITLE
Add permissions to annotation

### DIFF
--- a/src/main/java/com/publicuhc/pluginframework/routing/CommandMethod.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/CommandMethod.java
@@ -28,7 +28,11 @@ import java.lang.annotation.*;
 @Documented
 public @interface CommandMethod
 {
+    public static final String NO_PERMISSIONS = "NO PERMISSIONS REQUIRED";
+
     public String command();
 
     public boolean options() default false;
+
+    public String permission() default NO_PERMISSIONS;
 }

--- a/src/main/java/com/publicuhc/pluginframework/routing/CommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/CommandRoute.java
@@ -47,6 +47,11 @@ public interface CommandRoute
     public String getCommandName();
 
     /**
+     * @return permission required to run the command or null if no permission required
+     */
+    public String getPermission();
+
+    /**
      * Run this command route
      *
      * @param args the args for the method

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
@@ -35,12 +35,14 @@ public class DefaultCommandRoute implements CommandRoute
     private final MethodProxy proxy;
     private final CommandOptionsParser parser;
     private final String commandName;
+    private final String permission;
 
-    public DefaultCommandRoute(String commandName, MethodProxy proxy, CommandOptionsParser parser)
+    public DefaultCommandRoute(String commandName, String permission, MethodProxy proxy, CommandOptionsParser parser)
     {
         this.commandName = commandName;
         this.proxy = proxy;
         this.parser = parser;
+        this.permission = permission.equals(CommandMethod.NO_PERMISSIONS) ? null : permission;
     }
 
     @Override
@@ -72,5 +74,10 @@ public class DefaultCommandRoute implements CommandRoute
     public String getCommandName()
     {
         return commandName;
+    }
+
+    @Override
+    public String getPermission() {
+        return permission;
     }
 }

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultRouter.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultRouter.java
@@ -27,6 +27,7 @@ import com.publicuhc.pluginframework.routing.exception.CommandInvocationExceptio
 import com.publicuhc.pluginframework.routing.exception.CommandParseException;
 import com.publicuhc.pluginframework.routing.parser.RoutingMethodParser;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
@@ -154,6 +155,13 @@ public class DefaultRouter implements Router
             for(String message : messages) {
                 sender.sendMessage(message);
             }
+            return true;
+        }
+
+        //check permissions
+        String permission = route.getPermission();
+        if(null != permission && !sender.hasPermission(permission)) {
+            sender.sendMessage(ChatColor.RED + "You do not have permission to run that command. (" + permission + ")");
             return true;
         }
 

--- a/src/main/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParser.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParser.java
@@ -93,7 +93,7 @@ public class DefaultRoutingMethodParser extends RoutingMethodParser
 
         MethodProxy proxy = new ReflectionMethodProxy(instance, method);
 
-        return new DefaultCommandRoute(annotation.command(), proxy, optionParser);
+        return new DefaultCommandRoute(annotation.command(), annotation.permission(), proxy, optionParser);
     }
 
     @Override

--- a/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
@@ -26,6 +26,7 @@ import com.publicuhc.pluginframework.routing.parser.CommandOptionsParser;
 import com.publicuhc.pluginframework.routing.proxy.MethodProxy;
 import com.publicuhc.pluginframework.routing.proxy.ReflectionMethodProxy;
 import junit.framework.AssertionFailedError;
+import net.minecraft.server.v1_7_R4.CommandMe;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.craftbukkit.libs.joptsimple.OptionSet;
@@ -62,6 +63,18 @@ public class DefaultCommandRouteTest
         nonOptions.add("a");
         nonOptions.add("abc");
         when(set.nonOptionArguments()).thenReturn(nonOptions);
+    }
+
+    @Test
+    public void test_permission_set_default() throws NoSuchMethodException {
+        Method method = TestClass.class.getMethod("testMethod", CommandRequest.class);
+        MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
+
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser);
+        assertThat(route.getPermission()).isNull();
+
+        route = new DefaultCommandRoute("test", "TEST.PERMISSION", proxy, parser);
+        assertThat(route.getPermission()).isEqualTo("TEST.PERMISSION");
     }
 
     @Test

--- a/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
@@ -69,7 +69,7 @@ public class DefaultCommandRouteTest
     {
         Method method = TestClass.class.getMethod("testMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
-        DefaultCommandRoute route = new DefaultCommandRoute("test", proxy, parser);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser);
 
         Command command = mock(Command.class);
         CommandSender sender = mock(CommandSender.class);
@@ -91,7 +91,7 @@ public class DefaultCommandRouteTest
     {
         Method method = TestClass.class.getMethod("exceptionMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
-        DefaultCommandRoute route = new DefaultCommandRoute("test", proxy, parser);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser);
 
         Command command = mock(Command.class);
         CommandSender sender = mock(CommandSender.class);

--- a/src/test/java/com/publicuhc/pluginframework/routing/DefaultRouterTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/DefaultRouterTest.java
@@ -166,6 +166,23 @@ public class DefaultRouterTest
     }
 
     @Test
+    public void test_permissions_message() throws CommandParseException {
+        CommandSender sender = mock(CommandSender.class);
+        Command command = Bukkit.getPluginCommand("testcommand");
+        router.registerCommands(new PermCommandClass(), false);
+
+        when(sender.hasPermission("TEST.PERMISSION")).thenReturn(false);
+        boolean s = router.onCommand(sender, command, "", new String[]{});
+        assertThat(s).isTrue();
+        verify(sender).sendMessage(contains("TEST.PERMISSION"));
+
+        when(sender.hasPermission("TEST.PERMISSION")).thenReturn(true);
+        s = router.onCommand(sender, command, "", new String[]{});
+        assertThat(s).isTrue();
+        verify(sender).sendMessage(contains("success"));
+    }
+
+    @Test
     public void test_run_command_route() throws CommandParseException
     {
         SampleCommandClass sample = new SampleCommandClass();
@@ -215,6 +232,15 @@ public class DefaultRouterTest
             parser.accepts("b").withOptionalArg();
 
             return new String[]{"a"};
+        }
+    }
+
+    public class PermCommandClass
+    {
+        @CommandMethod(command = "testcommand", permission = "TEST.PERMISSION")
+        public void testCommand(CommandRequest request)
+        {
+            request.sendMessage("success");
         }
     }
 

--- a/src/test/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParserTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParserTest.java
@@ -55,7 +55,7 @@ public class DefaultRoutingMethodParserTest
     }
 
     //sample methods to use in tests
-    @CommandMethod(command = "test", options = true)
+    @CommandMethod(command = "test", options = true, permission = "TEST.PERMISSION")
     public String commandWithAnnotation(CommandRequest request)
     {
         return "TEST_STRING";
@@ -172,6 +172,19 @@ public class DefaultRoutingMethodParserTest
         Method method = DefaultRoutingMethodParserTest.class.getDeclaredMethod("commandWithAnnotation", CommandRequest.class);
         CommandOptionsParser optionParser = parser.getOptionsForMethod(method, this);
         assertOptionsValid(optionParser);
+    }
+
+    @Test
+    public void test_parse_permissions() throws NoSuchMethodException, CommandParseException {
+        Method method = DefaultRoutingMethodParserTest.class.getDeclaredMethod("commandWithAnnotation", CommandRequest.class);
+
+        CommandRoute route = parser.parseCommandMethodAnnotation(method, this);
+        assertThat(route.getPermission().equals("TEST.PERMISSION"));
+
+        method = DefaultRoutingMethodParserTest.class.getDeclaredMethod("commandWithAnnotationOptions", CommandRequest.class);
+
+        route = parser.parseCommandMethodAnnotation(method, this);
+        assertThat(route.getPermission()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Adds the permissions tag to the CommandMethod annotation that restricts the method to the given permission
