### PR TITLE
Argument Converters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version>0.2-SNAPSHOT</version>
 
     <properties>
-        <bukkit.version>LATEST</bukkit.version>
+        <bukkit.version>1.7.9-R0.2</bukkit.version>
         <mcstats.version>R8-SNAPSHOT</mcstats.version>
         <junit.version>4.11</junit.version>
         <mockito.version>1.9.5</mockito.version>

--- a/src/main/java/com/publicuhc/pluginframework/routing/converters/CoordinatesValueConverter.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/converters/CoordinatesValueConverter.java
@@ -1,0 +1,43 @@
+package com.publicuhc.pluginframework.routing.converters;
+
+import com.publicuhc.pluginframework.util.Coordinates;
+import joptsimple.ValueConversionException;
+import joptsimple.ValueConverter;
+
+/**
+ * Converts arguments in the format x,y,z to a coordinate.
+ * If supplied in the format x,z then y will be set to 0
+ */
+public class CoordinatesValueConverter implements ValueConverter<Coordinates> {
+    @Override
+    public Coordinates convert(String value) {
+        String[] parts = value.split(",");
+        if(parts.length < 2 || parts.length > 3)
+            throw new ValueConversionException("Invalid coordinates format");
+
+        Double[] parsed = new Double[parts.length];
+        try {
+            for (int i = 0; i < parts.length; i++) {
+                parsed[i] = Double.parseDouble(parts[i]);
+            }
+        } catch (NumberFormatException ex) {
+            throw new ValueConversionException("Invalid coordinate value");
+        }
+
+        double x = parsed[0];
+        double y = parsed.length == 3 ? parsed[1] : 0;
+        double z = parsed[parsed.length - 1];
+
+        return new Coordinates(x, y, z);
+    }
+
+    @Override
+    public Class<Coordinates> valueType() {
+        return Coordinates.class;
+    }
+
+    @Override
+    public String valuePattern() {
+        return null;
+    }
+}

--- a/src/main/java/com/publicuhc/pluginframework/routing/converters/LocationValueConverter.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/converters/LocationValueConverter.java
@@ -1,0 +1,43 @@
+package com.publicuhc.pluginframework.routing.converters;
+
+import com.publicuhc.pluginframework.util.Coordinates;
+import joptsimple.ValueConversionException;
+import joptsimple.ValueConverter;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+
+/**
+ * Converts locations in the formats:
+ *   world,x,y,z
+ *   world,x,z
+ */
+public class LocationValueConverter implements ValueConverter<Location> {
+    @Override
+    public Location convert(String value) {
+        int firstComma = value.indexOf(",");
+        if(-1 == firstComma)
+            throw new ValueConversionException("Invalid format");
+
+        String worldname = value.substring(0, firstComma);
+        World world = Bukkit.getWorld(worldname);
+        if(null == world)
+            throw new ValueConversionException("Invalid world name");
+
+        String coordinateString = value.substring(firstComma + 1);
+        CoordinatesValueConverter converter = new CoordinatesValueConverter();
+        Coordinates coords = converter.convert(coordinateString);
+
+        return coords.asLocationForWorld(world);
+    }
+
+    @Override
+    public Class<Location> valueType() {
+        return Location.class;
+    }
+
+    @Override
+    public String valuePattern() {
+        return null;
+    }
+}

--- a/src/main/java/com/publicuhc/pluginframework/routing/converters/OnlinePlayerValueConverter.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/converters/OnlinePlayerValueConverter.java
@@ -8,22 +8,40 @@ import org.bukkit.entity.Player;
 /**
  * Converts a online player name -> player object
  */
-public class OnlinePlayerValueConverter implements ValueConverter<Player> {
+public class OnlinePlayerValueConverter implements ValueConverter<Player[]> {
+
+    private final boolean allowStar;
+
+    /**
+     * A converter that converts player names to player objects
+     * @param allowStar if true, converts * to all online players
+     */
+    public OnlinePlayerValueConverter(boolean allowStar)
+    {
+        this.allowStar = allowStar;
+    }
+
     @Override
-    public Player convert(String value) {
+    public Player[] convert(String value)
+    {
+        if(allowStar && value.equals("*"))
+            return Bukkit.getOnlinePlayers();
+        @SuppressWarnings("deprecation")
         Player p = Bukkit.getPlayer(value);
         if(null == p)
             throw new ValueConversionException("Player not found online");
-        return p;
+        return new Player[]{p};
     }
 
     @Override
-    public Class<Player> valueType() {
-        return Player.class;
+    public Class<Player[]> valueType()
+    {
+        return Player[].class;
     }
 
     @Override
-    public String valuePattern() {
+    public String valuePattern()
+    {
         return null;
     }
 }

--- a/src/main/java/com/publicuhc/pluginframework/routing/converters/OnlinePlayerValueConverter.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/converters/OnlinePlayerValueConverter.java
@@ -1,0 +1,29 @@
+package com.publicuhc.pluginframework.routing.converters;
+
+import joptsimple.ValueConversionException;
+import joptsimple.ValueConverter;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * Converts a online player name -> player object
+ */
+public class OnlinePlayerValueConverter implements ValueConverter<Player> {
+    @Override
+    public Player convert(String value) {
+        Player p = Bukkit.getPlayer(value);
+        if(null == p)
+            throw new ValueConversionException("Player not found online");
+        return p;
+    }
+
+    @Override
+    public Class<Player> valueType() {
+        return Player.class;
+    }
+
+    @Override
+    public String valuePattern() {
+        return null;
+    }
+}

--- a/src/main/java/com/publicuhc/pluginframework/util/Coordinates.java
+++ b/src/main/java/com/publicuhc/pluginframework/util/Coordinates.java
@@ -1,0 +1,44 @@
+package com.publicuhc.pluginframework.util;
+
+public class Coordinates {
+
+    private double x,y,z;
+
+    public Coordinates(double x, double y, double z)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+
+    public double getX()
+    {
+        return x;
+    }
+
+    public void setX(double x)
+    {
+        this.x = x;
+    }
+
+    public double getY()
+    {
+        return y;
+    }
+
+    public void setY(double y)
+    {
+        this.y = y;
+    }
+
+    public double getZ()
+    {
+        return z;
+    }
+
+    public void setZ(double z)
+    {
+        this.z = z;
+    }
+}

--- a/src/main/java/com/publicuhc/pluginframework/util/Coordinates.java
+++ b/src/main/java/com/publicuhc/pluginframework/util/Coordinates.java
@@ -1,5 +1,8 @@
 package com.publicuhc.pluginframework.util;
 
+import org.bukkit.Location;
+import org.bukkit.World;
+
 public class Coordinates {
 
     private double x,y,z;
@@ -11,6 +14,10 @@ public class Coordinates {
         this.z = z;
     }
 
+    public Location asLocationForWorld(World world)
+    {
+        return new Location(world, x, y, z);
+    }
 
     public double getX()
     {

--- a/src/test/java/com/publicuhc/pluginframework/routing/converter/CoordinatesValueConverterTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/converter/CoordinatesValueConverterTest.java
@@ -1,0 +1,80 @@
+package com.publicuhc.pluginframework.routing.converter;
+
+import com.publicuhc.pluginframework.routing.converters.CoordinatesValueConverter;
+import com.publicuhc.pluginframework.util.Coordinates;
+import joptsimple.ValueConversionException;
+import joptsimple.ValueConverter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(PowerMockRunner.class)
+public class CoordinatesValueConverterTest {
+
+    CoordinatesValueConverter converter;
+
+    @Before
+    public void onStartup()
+    {
+        converter = new CoordinatesValueConverter();
+    }
+
+    @Test(expected = ValueConversionException.class)
+    public void testTooMany()
+    {
+        converter.convert("1,20,20,22");
+    }
+
+    @Test(expected = ValueConversionException.class)
+    public void testTooLittle()
+    {
+        converter.convert("1");
+    }
+
+    @Test(expected = ValueConversionException.class)
+    public void testInvalid()
+    {
+        converter.convert("1,sdjh,22");
+    }
+
+    @Test
+    public void testTwoCoords()
+    {
+        Coordinates coordinates = converter.convert("1,10");
+        assertThat(coordinates.getX()).isEqualTo(1);
+        assertThat(coordinates.getY()).isEqualTo(0);
+        assertThat(coordinates.getZ()).isEqualTo(10);
+
+        coordinates = converter.convert("1.987,-290");
+        assertThat(coordinates.getX()).isEqualTo(1.987);
+        assertThat(coordinates.getY()).isEqualTo(0);
+        assertThat(coordinates.getZ()).isEqualTo(-290);
+
+        coordinates = converter.convert("1.987e8,-290");
+        assertThat(coordinates.getX()).isEqualTo(198700000);
+        assertThat(coordinates.getY()).isEqualTo(0);
+        assertThat(coordinates.getZ()).isEqualTo(-290);
+    }
+
+    @Test
+    public void testThreeCoords()
+    {
+        Coordinates coordinates = converter.convert("1,27,10");
+        assertThat(coordinates.getX()).isEqualTo(1);
+        assertThat(coordinates.getY()).isEqualTo(27);
+        assertThat(coordinates.getZ()).isEqualTo(10);
+
+        coordinates = converter.convert("1.987,38,-290");
+        assertThat(coordinates.getX()).isEqualTo(1.987);
+        assertThat(coordinates.getY()).isEqualTo(38);
+        assertThat(coordinates.getZ()).isEqualTo(-290);
+
+        coordinates = converter.convert("1.987e8,-299,-290");
+        assertThat(coordinates.getX()).isEqualTo(198700000);
+        assertThat(coordinates.getY()).isEqualTo(-299);
+        assertThat(coordinates.getZ()).isEqualTo(-290);
+    }
+}

--- a/src/test/java/com/publicuhc/pluginframework/routing/converter/LocationValueConverterTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/converter/LocationValueConverterTest.java
@@ -1,0 +1,75 @@
+package com.publicuhc.pluginframework.routing.converter;
+
+import com.publicuhc.pluginframework.routing.converters.LocationValueConverter;
+import joptsimple.ValueConversionException;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Bukkit.class)
+public class LocationValueConverterTest {
+
+    LocationValueConverter converter;
+    World world;
+
+    @Before
+    public void onStartup()
+    {
+        converter = new LocationValueConverter();
+        mockStatic(Bukkit.class);
+        world = mock(World.class);
+        when(Bukkit.getWorld("valid")).thenReturn(world);
+        when(Bukkit.getWorld("invalid")).thenReturn(null);
+    }
+
+    @Test
+    public void testValidTwo()
+    {
+        Location loc = converter.convert("valid,-1,20");
+
+        assertThat(loc.getWorld()).isSameAs(world);
+        assertThat(loc.getX()).isEqualTo(-1);
+        assertThat(loc.getY()).isEqualTo(0);
+        assertThat(loc.getZ()).isEqualTo(20);
+    }
+
+    @Test
+    public void testValidThree()
+    {
+        Location loc = converter.convert("valid,-1,92,20");
+
+        assertThat(loc.getWorld()).isSameAs(world);
+        assertThat(loc.getX()).isEqualTo(-1);
+        assertThat(loc.getY()).isEqualTo(92);
+        assertThat(loc.getZ()).isEqualTo(20);
+    }
+
+    @Test(expected = ValueConversionException.class)
+    public void testInvalidWorld()
+    {
+        converter.convert("invalid,-1,20");
+    }
+
+    @Test(expected = ValueConversionException.class)
+    public void testInvalid()
+    {
+        converter.convert("jskd");
+    }
+
+    @Test(expected = ValueConversionException.class)
+    public void testInvalidCoord()
+    {
+        converter.convert("valid,-1,20,298,2098");
+    }
+}

--- a/src/test/java/com/publicuhc/pluginframework/routing/converter/OnlinePlayerValueConverterTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/converter/OnlinePlayerValueConverterTest.java
@@ -1,0 +1,49 @@
+package com.publicuhc.pluginframework.routing.converter;
+
+import com.publicuhc.pluginframework.routing.converters.OnlinePlayerValueConverter;
+import joptsimple.ValueConversionException;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Bukkit.class)
+public class OnlinePlayerValueConverterTest {
+
+    OnlinePlayerValueConverter converter;
+    Player player;
+
+    @Before
+    public void onStartup()
+    {
+        converter = new OnlinePlayerValueConverter();
+        mockStatic(Bukkit.class);
+
+        //make ghowden not online, make eluinhost online
+        when(Bukkit.getPlayer("ghowden")).thenReturn(null);
+        player = mock(Player.class);
+        when(Bukkit.getPlayer("eluinhost")).thenReturn(player);
+    }
+
+    @Test
+    public void testValidPlayer()
+    {
+        Player player = converter.convert("eluinhost");
+        assertThat(player).isSameAs(this.player);
+    }
+
+    @Test(expected = ValueConversionException.class)
+    public void testNotFound()
+    {
+        converter.convert("ghowden");
+    }
+}

--- a/src/test/java/com/publicuhc/pluginframework/routing/converter/OnlinePlayerValueConverterTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/converter/OnlinePlayerValueConverterTest.java
@@ -19,31 +19,47 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest(Bukkit.class)
 public class OnlinePlayerValueConverterTest {
 
-    OnlinePlayerValueConverter converter;
     Player player;
 
     @Before
     public void onStartup()
     {
-        converter = new OnlinePlayerValueConverter();
         mockStatic(Bukkit.class);
 
         //make ghowden not online, make eluinhost online
         when(Bukkit.getPlayer("ghowden")).thenReturn(null);
         player = mock(Player.class);
         when(Bukkit.getPlayer("eluinhost")).thenReturn(player);
+        when(Bukkit.getOnlinePlayers()).thenReturn(new Player[]{player});
     }
 
     @Test
     public void testValidPlayer()
     {
-        Player player = converter.convert("eluinhost");
-        assertThat(player).isSameAs(this.player);
+        OnlinePlayerValueConverter converter = new OnlinePlayerValueConverter(false);
+        Player[] players = converter.convert("eluinhost");
+        assertThat(players).containsExactly(player);
     }
 
     @Test(expected = ValueConversionException.class)
     public void testNotFound()
     {
+        OnlinePlayerValueConverter converter = new OnlinePlayerValueConverter(false);
         converter.convert("ghowden");
+    }
+
+    @Test
+    public void testAllOnline()
+    {
+        OnlinePlayerValueConverter converter = new OnlinePlayerValueConverter(true);
+        Player[] players = converter.convert("*");
+        assertThat(players).containsExactly(player);
+    }
+
+    @Test(expected = ValueConversionException.class)
+    public void testStar()
+    {
+        OnlinePlayerValueConverter converter = new OnlinePlayerValueConverter(false);
+        converter.convert("*");
     }
 }


### PR DESCRIPTION
Converters to use with parser configurations like:

parser.accepts("p").withRequiredArg().withValuesConvertedBy(new OnlinePlayerValueConverter()).describedAs("Player to teleport to");

Adds the following converters:
- OnlinePlayerValueConverter - converts to an online player of the same name
- CoordinatesValueConverter - converts x,z or x,y,z into a coordinates object (worldless)
- LocationValueConverter - converts world,x,z or world,x,y,z into a Location object
