### PR TITLE
Be able to specify a help option

### DIFF
--- a/src/main/java/com/publicuhc/pluginframework/routing/CommandMethod.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/CommandMethod.java
@@ -29,10 +29,13 @@ import java.lang.annotation.*;
 public @interface CommandMethod
 {
     public static final String NO_PERMISSIONS = "NO PERMISSIONS REQUIRED";
+    public static final String DEFAULT_HELP = "?";
 
     public String command();
 
     public boolean options() default false;
 
     public String permission() default NO_PERMISSIONS;
+
+    public String helpOption() default DEFAULT_HELP;
 }

--- a/src/main/java/com/publicuhc/pluginframework/routing/CommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/CommandRoute.java
@@ -23,7 +23,6 @@ package com.publicuhc.pluginframework.routing;
 
 import com.publicuhc.pluginframework.routing.exception.CommandInvocationException;
 import com.publicuhc.pluginframework.routing.proxy.MethodProxy;
-import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -55,8 +54,7 @@ public interface CommandRoute
      * Run this command route
      *
      * @param args the args for the method
-     * @throws joptsimple.OptionException   when options do not match expected
      * @throws com.publicuhc.pluginframework.routing.exception.CommandInvocationException if exception thrown in command
      */
-    public void run(Command command, CommandSender sender, String[] args) throws OptionException, CommandInvocationException;
+    public void run(Command command, CommandSender sender, String[] args) throws CommandInvocationException;
 }

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
@@ -83,8 +83,9 @@ public class DefaultCommandRoute implements CommandRoute
             OptionSet optionSet = parser.parse(args);
             if(optionSet.has(helpSpec)) {
                 printHelpFor(sender);
+            } else {
+                proxy.invoke(new CommandRequest(command, sender, optionSet));
             }
-            proxy.invoke(new CommandRequest(command, sender, optionSet));
         } catch(OptionException e) {
             printHelpFor(sender);
         } catch(Throwable e) {

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
@@ -26,8 +26,12 @@ import com.publicuhc.pluginframework.routing.proxy.MethodProxy;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+
+import java.io.IOException;
+import java.io.StringWriter;
 
 public class DefaultCommandRoute implements CommandRoute
 {
@@ -36,9 +40,11 @@ public class DefaultCommandRoute implements CommandRoute
     private final OptionParser parser;
     private final String commandName;
     private final String permission;
+    private final OptionSpec helpSpec;
 
-    public DefaultCommandRoute(String commandName, String permission, MethodProxy proxy, OptionParser parser)
+    public DefaultCommandRoute(String commandName, String permission, MethodProxy proxy, OptionParser parser, OptionSpec helpSpec)
     {
+        this.helpSpec = helpSpec;
         this.commandName = commandName;
         this.proxy = proxy;
         this.parser = parser;
@@ -57,14 +63,30 @@ public class DefaultCommandRoute implements CommandRoute
         return proxy;
     }
 
+    private void printHelpFor(CommandSender sender)
+    {
+        //catch the option exceptions and print an error message out with the option syntax
+        StringWriter writer = new StringWriter();
+        try {
+            parser.printHelpOn(writer);
+            sender.sendMessage(writer.toString());
+        } catch(IOException ioex) {
+            //shouldn't run, if it does the world probably exploded
+            ioex.printStackTrace();
+        }
+    }
+
     @Override
-    public void run(Command command, CommandSender sender, String[] args) throws OptionException, CommandInvocationException
+    public void run(Command command, CommandSender sender, String[] args) throws CommandInvocationException
     {
         try {
             OptionSet optionSet = parser.parse(args);
+            if(optionSet.has(helpSpec)) {
+                printHelpFor(sender);
+            }
             proxy.invoke(new CommandRequest(command, sender, optionSet));
         } catch(OptionException e) {
-            throw e;
+            printHelpFor(sender);
         } catch(Throwable e) {
             throw new CommandInvocationException("Exception thrown when running the command " + command.getName(), e);
         }

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultRouter.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultRouter.java
@@ -26,15 +26,12 @@ import com.google.inject.Injector;
 import com.publicuhc.pluginframework.routing.exception.CommandInvocationException;
 import com.publicuhc.pluginframework.routing.exception.CommandParseException;
 import com.publicuhc.pluginframework.routing.parser.RoutingMethodParser;
-import joptsimple.OptionException;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -168,17 +165,6 @@ public class DefaultRouter implements Router
         //run the actual command
         try {
             route.run(command, sender, args);
-        } catch(OptionException ex) {
-            //catch the option exceptions and print an error message out with the option syntax
-            StringWriter writer = new StringWriter();
-            try {
-                route.getOptionDetails().printHelpOn(writer);
-                sender.sendMessage(writer.toString());
-                return true;
-            } catch(IOException ioex) {
-                ex.printStackTrace();
-                return false;
-            }
         } catch(CommandInvocationException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParser.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParser.java
@@ -21,13 +21,17 @@
 
 package com.publicuhc.pluginframework.routing.parser;
 
-import com.publicuhc.pluginframework.routing.*;
+import com.publicuhc.pluginframework.routing.CommandMethod;
+import com.publicuhc.pluginframework.routing.CommandRequest;
+import com.publicuhc.pluginframework.routing.CommandRoute;
+import com.publicuhc.pluginframework.routing.DefaultCommandRoute;
 import com.publicuhc.pluginframework.routing.exception.AnnotationMissingException;
 import com.publicuhc.pluginframework.routing.exception.CommandParseException;
 import com.publicuhc.pluginframework.routing.help.BukkitHelpFormatter;
 import com.publicuhc.pluginframework.routing.proxy.MethodProxy;
 import com.publicuhc.pluginframework.routing.proxy.ReflectionMethodProxy;
 import joptsimple.OptionParser;
+import joptsimple.OptionSpec;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -90,10 +94,11 @@ public class DefaultRoutingMethodParser extends RoutingMethodParser
         }
 
         optionParser.formatHelpWith(new BukkitHelpFormatter());
+        OptionSpec helpSpec = optionParser.accepts(annotation.helpOption(), "Help").forHelp();
 
         MethodProxy proxy = new ReflectionMethodProxy(instance, method);
 
-        return new DefaultCommandRoute(annotation.command(), annotation.permission(), proxy, optionParser);
+        return new DefaultCommandRoute(annotation.command(), annotation.permission(), proxy, optionParser, helpSpec);
     }
 
     @Override

--- a/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
@@ -26,6 +26,7 @@ import com.publicuhc.pluginframework.routing.proxy.MethodProxy;
 import com.publicuhc.pluginframework.routing.proxy.ReflectionMethodProxy;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 import junit.framework.AssertionFailedError;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -49,6 +50,7 @@ import static org.powermock.api.mockito.PowerMockito.*;
 public class DefaultCommandRouteTest
 {
     private OptionParser parser;
+    private OptionSpec helpSpec;
     private TestClass testObject;
 
     @Before
@@ -56,6 +58,7 @@ public class DefaultCommandRouteTest
     {
         testObject = new TestClass();
         parser = mock(OptionParser.class);
+        helpSpec = mock(OptionSpec.class);
         OptionSet set = mock(OptionSet.class);
         when(parser.parse(Matchers.<String[]>anyVararg())).thenReturn(set);
         List nonOptions = new ArrayList<String>();
@@ -69,10 +72,10 @@ public class DefaultCommandRouteTest
         Method method = TestClass.class.getMethod("testMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
 
-        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser, helpSpec);
         assertThat(route.getPermission()).isNull();
 
-        route = new DefaultCommandRoute("test", "TEST.PERMISSION", proxy, parser);
+        route = new DefaultCommandRoute("test", "TEST.PERMISSION", proxy, parser, helpSpec);
         assertThat(route.getPermission()).isEqualTo("TEST.PERMISSION");
     }
 
@@ -81,7 +84,7 @@ public class DefaultCommandRouteTest
     {
         Method method = TestClass.class.getMethod("testMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
-        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser, helpSpec);
 
         Command command = mock(Command.class);
         CommandSender sender = mock(CommandSender.class);
@@ -103,7 +106,7 @@ public class DefaultCommandRouteTest
     {
         Method method = TestClass.class.getMethod("exceptionMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
-        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser, helpSpec);
 
         Command command = mock(Command.class);
         CommandSender sender = mock(CommandSender.class);

--- a/src/test/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParserTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParserTest.java
@@ -112,6 +112,13 @@ public class DefaultRoutingMethodParserTest
     public void commandWithInvalidOptionsParam(OptionSet set)
     {}
 
+    @CommandMethod(command = "test", helpOption = "t", options = true)
+    public void commandWithNonStandardHelp(CommandRequest request)
+    {}
+
+    public void commandWithNonStandardHelp(OptionParser optionParser)
+    {}
+
     //helpful methods
     private void assertOptionsValid(OptionParser optionParser)
     {
@@ -174,11 +181,15 @@ public class DefaultRoutingMethodParserTest
 
         CommandRoute route = parser.parseCommandMethodAnnotation(method, this);
         assertThat(route.getPermission().equals("TEST.PERMISSION"));
+        assertThat(route.getOptionDetails().recognizedOptions()).containsKey("?");
+        assertThat(route.getOptionDetails().recognizedOptions()).doesNotContainKey("t");
 
         method = DefaultRoutingMethodParserTest.class.getDeclaredMethod("commandWithAnnotationOptions", CommandRequest.class);
 
         route = parser.parseCommandMethodAnnotation(method, this);
         assertThat(route.getPermission()).isNull();
+        assertThat(route.getOptionDetails().recognizedOptions()).containsKey("?");
+        assertThat(route.getOptionDetails().recognizedOptions()).doesNotContainKey("t");
     }
 
     @Test
@@ -193,6 +204,8 @@ public class DefaultRoutingMethodParserTest
         MethodProxy proxy = route.getProxy();
         assertThat(proxy.getInstance()).isSameAs(this);
         assertThat(proxy.invoke(mock(CommandRequest.class))).isEqualTo("TEST_STRING");
+        assertThat(route.getOptionDetails().recognizedOptions()).containsKey("?");
+        assertThat(route.getOptionDetails().recognizedOptions()).doesNotContainKey("t");
     }
 
     @Test
@@ -260,6 +273,8 @@ public class DefaultRoutingMethodParserTest
         assertThat(route.getCommandName()).isEqualTo("test");
         assertOptionsValidStrings(route.getOptionDetails());
         assertThat(route.getProxy().invoke(mock(CommandRequest.class))).isEqualTo("TEST_STRING");
+        assertThat(route.getOptionDetails().recognizedOptions()).containsKey("?");
+        assertThat(route.getOptionDetails().recognizedOptions()).doesNotContainKey("t");
     }
 
     @Test
@@ -289,5 +304,14 @@ public class DefaultRoutingMethodParserTest
         } catch(CommandParseException ex) {
             assertThat(ex.getMessage()).contains("Invalid command method parameters");
         }
+    }
+
+    @Test
+    public void test_parse_command_method_non_standard_help() throws NoSuchMethodException, CommandParseException {
+        Method method = DefaultRoutingMethodParserTest.class.getDeclaredMethod("commandWithNonStandardHelp", CommandRequest.class);
+        CommandRoute route = parser.parseCommandMethodAnnotation(method, this);
+
+        assertThat(route.getOptionDetails().recognizedOptions()).containsKey("t");
+        assertThat(route.getOptionDetails().recognizedOptions()).doesNotContainKey("?");
     }
 }


### PR DESCRIPTION
Adds a param to the command method annotation to specify a help option which if found will show the help message instead. Defaults to '?' if not provided. Delegates help printing to the command route instead of the router itself
