### PR TITLE
Allow custom modules on command register

### DIFF
--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultRouter.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultRouter.java
@@ -21,6 +21,7 @@
 
 package com.publicuhc.pluginframework.routing;
 
+import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.publicuhc.pluginframework.routing.exception.CommandInvocationException;
@@ -68,10 +69,17 @@ public class DefaultRouter implements Router
     }
 
     @Override
-    public Object registerCommands(Class klass) throws CommandParseException
+    public Object registerCommands(Class klass) throws CommandParseException {
+        return registerCommands(klass, new ArrayList<AbstractModule>());
+    }
+
+    @Override
+    public Object registerCommands(Class klass, List<AbstractModule> modules) throws CommandParseException
     {
+        Injector childInjector = injector.createChildInjector(modules);
+
         //grab an instance of the class after injection
-        Object o = injector.getInstance(klass);
+        Object o = childInjector.getInstance(klass);
 
         //register it using the instanced version without injection
         registerCommands(o, false);
@@ -81,11 +89,17 @@ public class DefaultRouter implements Router
     }
 
     @Override
-    public void registerCommands(Object object, boolean inject) throws CommandParseException
+    public void registerCommands(Object object, boolean inject) throws CommandParseException {
+        registerCommands(object, inject, new ArrayList<AbstractModule>());
+    }
+
+    @Override
+    public void registerCommands(Object object, boolean inject, List<AbstractModule> modules) throws CommandParseException
     {
         //inject if we need to
         if(inject) {
-            injector.injectMembers(object);
+            Injector childInjector = injector.createChildInjector(modules);
+            childInjector.injectMembers(object);
         }
 
         //the class of our object

--- a/src/main/java/com/publicuhc/pluginframework/routing/Router.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/Router.java
@@ -21,6 +21,7 @@
 
 package com.publicuhc.pluginframework.routing;
 
+import com.google.inject.AbstractModule;
 import com.publicuhc.pluginframework.routing.exception.CommandParseException;
 import org.bukkit.command.TabExecutor;
 
@@ -30,7 +31,7 @@ public interface Router extends TabExecutor
 {
 
     /**
-     * Register a class for commands, creates a new instance using the DI injector
+     * Register a class for commands. Creates a new instance of said class and injects it using the default DI injector.
      *
      * @param klass the class to register commands for
      * @return the created object after injection
@@ -39,10 +40,21 @@ public interface Router extends TabExecutor
     Object registerCommands(Class klass) throws CommandParseException;
 
     /**
-     * Register an already created class for commands and (optionally) inject dependencies
+     * Register a class for commands. Creates a new instance of said class and injects it using the default DI injector
+     * with the provided modules added
+     *
+     * @param klass the class to register commands for
+     * @param modules the extra modules to add to the injector
+     * @return the created object after injection
+     * @throws com.publicuhc.pluginframework.routing.exception.CommandParseException when failing to parse any commands in the class
+     */
+    Object registerCommands(Class klass, List<AbstractModule> modules) throws CommandParseException;
+
+    /**
+     * Register an instance for commands, optionally injecting using the DI injector
      * <b>
-     * If injecting dependencies construction injection doesn't happen,
-     * use {@link #registerCommands(Class)} to do constructor injection</b>
+     * If injecting dependencies construction/property injection doesn't happen,
+     * use {@link #registerCommands(Class)} to do constructor/property injection</b>
      * </b>
      *
      * @param object the object to register commands for
@@ -50,6 +62,19 @@ public interface Router extends TabExecutor
      * @throws com.publicuhc.pluginframework.routing.exception.CommandParseException when failing to parse any commands in the class
      */
     void registerCommands(Object object, boolean inject) throws CommandParseException;
+
+    /**
+     * Register an instance for commands, optionally injecting using the DI injector with the extra provided modules
+     * <b>
+     * If injecting dependencies construction/property injection doesn't happen,
+     * use {@link #registerCommands(Class, List)} to do constructor/property injection</b>
+     * </b>
+     *
+     * @param object the object to register commands for
+     * @param inject whether to inject dependencies or not (no constructor injection)
+     * @throws com.publicuhc.pluginframework.routing.exception.CommandParseException when failing to parse any commands in the class
+     */
+    void registerCommands(Object object, boolean inject, List<AbstractModule> modules) throws CommandParseException;
 
     /**
      * Set the messages to be displayed if a command is triggered but has no method to call

--- a/src/test/java/com/publicuhc/pluginframework/matchers/ListOfSize.java
+++ b/src/test/java/com/publicuhc/pluginframework/matchers/ListOfSize.java
@@ -1,0 +1,20 @@
+package com.publicuhc.pluginframework.matchers;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.List;
+
+public class ListOfSize extends ArgumentMatcher<List> {
+
+    private final int size;
+
+    public ListOfSize(int size)
+    {
+        this.size = size;
+    }
+
+    @Override
+    public boolean matches(Object argument) {
+        return argument instanceof List && ((List) argument).size() == size;
+    }
+}

--- a/src/test/java/com/publicuhc/pluginframework/matchers/UHCMatchers.java
+++ b/src/test/java/com/publicuhc/pluginframework/matchers/UHCMatchers.java
@@ -1,0 +1,13 @@
+package com.publicuhc.pluginframework.matchers;
+
+import java.util.List;
+
+import static org.mockito.Matchers.argThat;
+
+public class UHCMatchers {
+
+    public static List listOfSize(int size)
+    {
+        return argThat(new ListOfSize(size));
+    }
+}


### PR DESCRIPTION
Allows registering of extra modules on command register for the DI container to use for that command only. Allows per-command dependencies
