### PR TITLE
Add allowedSenders to @CommandMethod

### DIFF
--- a/src/main/java/com/publicuhc/pluginframework/routing/CommandMethod.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/CommandMethod.java
@@ -21,6 +21,8 @@
 
 package com.publicuhc.pluginframework.routing;
 
+import org.bukkit.command.CommandSender;
+
 import java.lang.annotation.*;
 
 @Retention(RetentionPolicy.RUNTIME)
@@ -38,4 +40,6 @@ public @interface CommandMethod
     public String permission() default NO_PERMISSIONS;
 
     public String helpOption() default DEFAULT_HELP;
+
+    public Class<? extends CommandSender>[] allowedSenders() default CommandSender.class;
 }

--- a/src/main/java/com/publicuhc/pluginframework/routing/CommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/CommandRoute.java
@@ -51,6 +51,11 @@ public interface CommandRoute
     public String getPermission();
 
     /**
+     * @return a array of classes (or subclasses of) which are allowed to be command senders to trigger the command
+     */
+    public Class<? extends CommandSender>[] getAllowedSenders();
+
+    /**
      * Run this command route
      *
      * @param args the args for the method

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
@@ -121,4 +121,10 @@ public class DefaultCommandRoute implements CommandRoute
     public String getPermission() {
         return permission;
     }
+
+    @Override
+    public Class<? extends CommandSender>[] getAllowedSenders()
+    {
+        return allowedSenders;
+    }
 }

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
@@ -42,13 +42,13 @@ public class DefaultCommandRoute implements CommandRoute
     private final String commandName;
     private final String permission;
     private final OptionSpec helpSpec;
-    private final Class<? extends CommandSender> allowedSender;
+    private final Class<? extends CommandSender>[] allowedSenders;
 
-    public DefaultCommandRoute(String commandName, String permission, Class<? extends CommandSender> allowedSender, MethodProxy proxy, OptionParser parser, OptionSpec helpSpec)
+    public DefaultCommandRoute(String commandName, String permission, Class<? extends CommandSender>[] allowedSenders, MethodProxy proxy, OptionParser parser, OptionSpec helpSpec)
     {
         this.helpSpec = helpSpec;
         this.commandName = commandName;
-        this.allowedSender = allowedSender;
+        this.allowedSenders = allowedSenders;
         this.proxy = proxy;
         this.parser = parser;
         this.permission = permission.equals(CommandMethod.NO_PERMISSIONS) ? null : permission;
@@ -79,10 +79,21 @@ public class DefaultCommandRoute implements CommandRoute
         }
     }
 
+    private boolean isSenderTypeAllowed(CommandSender sender)
+    {
+        Class<? extends CommandSender> senderClass = sender.getClass();
+        for(Class<? extends CommandSender> senderType : allowedSenders) {
+            if(senderType.isAssignableFrom(senderClass)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public void run(Command command, CommandSender sender, String[] args) throws CommandInvocationException
     {
-        if(!allowedSender.isAssignableFrom(sender.getClass())) {
+        if(!isSenderTypeAllowed(sender)) {
             sender.sendMessage(ChatColor.RED + "You cannot run that command from here!");
             return;
         }

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
@@ -27,6 +27,7 @@ import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 
@@ -41,11 +42,13 @@ public class DefaultCommandRoute implements CommandRoute
     private final String commandName;
     private final String permission;
     private final OptionSpec helpSpec;
+    private final Class<? extends CommandSender> allowedSender;
 
-    public DefaultCommandRoute(String commandName, String permission, MethodProxy proxy, OptionParser parser, OptionSpec helpSpec)
+    public DefaultCommandRoute(String commandName, String permission, Class<? extends CommandSender> allowedSender, MethodProxy proxy, OptionParser parser, OptionSpec helpSpec)
     {
         this.helpSpec = helpSpec;
         this.commandName = commandName;
+        this.allowedSender = allowedSender;
         this.proxy = proxy;
         this.parser = parser;
         this.permission = permission.equals(CommandMethod.NO_PERMISSIONS) ? null : permission;
@@ -79,6 +82,10 @@ public class DefaultCommandRoute implements CommandRoute
     @Override
     public void run(Command command, CommandSender sender, String[] args) throws CommandInvocationException
     {
+        if(!allowedSender.isAssignableFrom(sender.getClass())) {
+            sender.sendMessage(ChatColor.RED + "You cannot run that command from here!");
+            return;
+        }
         try {
             OptionSet optionSet = parser.parse(args);
             if(optionSet.has(helpSpec)) {

--- a/src/main/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParser.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParser.java
@@ -98,7 +98,7 @@ public class DefaultRoutingMethodParser extends RoutingMethodParser
 
         MethodProxy proxy = new ReflectionMethodProxy(instance, method);
 
-        return new DefaultCommandRoute(annotation.command(), annotation.permission(), proxy, optionParser, helpSpec);
+        return new DefaultCommandRoute(annotation.command(), annotation.permission(), annotation.allowedSenders(), proxy, optionParser, helpSpec);
     }
 
     @Override

--- a/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
@@ -31,6 +31,8 @@ import joptsimple.OptionSpec;
 import junit.framework.AssertionFailedError;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,6 +59,11 @@ public class DefaultCommandRouteTest
     private OptionSet set;
     private TestClass testObject;
 
+    @SuppressWarnings("unchecked")
+    private Class<? extends CommandSender>[] allSenders = (Class<? extends CommandSender>[]) new Class<?>[]{CommandSender.class};
+    @SuppressWarnings("unchecked")
+    private Class<? extends CommandSender>[] playerOrConsoleSender = (Class<? extends CommandSender>[]) new Class<?>[]{Player.class, ConsoleCommandSender.class};
+
     @Before
     public void onStartup() throws NoSuchMethodException
     {
@@ -76,10 +83,10 @@ public class DefaultCommandRouteTest
         Method method = TestClass.class.getMethod("testMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
 
-        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser, helpSpec);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, allSenders, proxy, parser, helpSpec);
         assertThat(route.getPermission()).isNull();
 
-        route = new DefaultCommandRoute("test", "TEST.PERMISSION", proxy, parser, helpSpec);
+        route = new DefaultCommandRoute("test", "TEST.PERMISSION", allSenders, proxy, parser, helpSpec);
         assertThat(route.getPermission()).isEqualTo("TEST.PERMISSION");
     }
 
@@ -88,7 +95,7 @@ public class DefaultCommandRouteTest
     {
         Method method = TestClass.class.getMethod("testMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
-        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser, helpSpec);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, allSenders, proxy, parser, helpSpec);
 
         Command command = mock(Command.class);
         CommandSender sender = mock(CommandSender.class);
@@ -112,7 +119,7 @@ public class DefaultCommandRouteTest
 
         Method method = TestClass.class.getMethod("testMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
-        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser, helpSpec);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, allSenders, proxy, parser, helpSpec);
 
         Command command = mock(Command.class);
         CommandSender sender = mock(CommandSender.class);
@@ -136,7 +143,7 @@ public class DefaultCommandRouteTest
 
         Method method = TestClass.class.getMethod("testMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
-        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser, helpSpec);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, allSenders, proxy, parser, helpSpec);
 
         Command command = mock(Command.class);
         CommandSender sender = mock(CommandSender.class);
@@ -158,7 +165,7 @@ public class DefaultCommandRouteTest
     {
         Method method = TestClass.class.getMethod("exceptionMethod", CommandRequest.class);
         MethodProxy proxy = spy(new ReflectionMethodProxy(testObject, method));
-        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, proxy, parser, helpSpec);
+        DefaultCommandRoute route = new DefaultCommandRoute("test", CommandMethod.NO_PERMISSIONS, allSenders, proxy, parser, helpSpec);
 
         Command command = mock(Command.class);
         CommandSender sender = mock(CommandSender.class);


### PR DESCRIPTION
Adds allowedSenders to @CommandMethod that only allows the command to be ran by the classes defined (or subclasses thereof)

Defaults to CommandSender (any sender)
