### PR TITLE
Support subcommands

### DIFF
--- a/src/main/java/com/publicuhc/pluginframework/routing/CommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/CommandRoute.java
@@ -51,6 +51,11 @@ public interface CommandRoute
     public String getPermission();
 
     /**
+     * @return the arguments to start with
+     */
+    public String[] getStartsWith();
+
+    /**
      * @return a array of classes (or subclasses of) which are allowed to be command senders to trigger the command
      */
     public Class<? extends CommandSender>[] getAllowedSenders();

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
@@ -33,6 +33,7 @@ import org.bukkit.command.CommandSender;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Arrays;
 
 public class DefaultCommandRoute implements CommandRoute
 {
@@ -40,6 +41,7 @@ public class DefaultCommandRoute implements CommandRoute
     private final MethodProxy proxy;
     private final OptionParser parser;
     private final String commandName;
+    private final String[] startsWith;
     private final String permission;
     private final OptionSpec helpSpec;
     private final Class<? extends CommandSender>[] allowedSenders;
@@ -47,11 +49,14 @@ public class DefaultCommandRoute implements CommandRoute
     public DefaultCommandRoute(String commandName, String permission, Class<? extends CommandSender>[] allowedSenders, MethodProxy proxy, OptionParser parser, OptionSpec helpSpec)
     {
         this.helpSpec = helpSpec;
-        this.commandName = commandName;
         this.allowedSenders = allowedSenders;
         this.proxy = proxy;
         this.parser = parser;
         this.permission = permission.equals(CommandMethod.NO_PERMISSIONS) ? null : permission;
+
+        String[] commandParts = commandName.split(" ");
+        this.commandName = commandParts[0];
+        this.startsWith = Arrays.copyOfRange(commandParts, 1, commandParts.length);
     }
 
     @Override
@@ -120,6 +125,12 @@ public class DefaultCommandRoute implements CommandRoute
     @Override
     public String getPermission() {
         return permission;
+    }
+
+    @Override
+    public String[] getStartsWith()
+    {
+        return startsWith;
     }
 
     @Override

--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultRouter.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultRouter.java
@@ -166,38 +166,40 @@ public class DefaultRouter implements Router
 
         int appliedRoutes = 0;
 
-        List<String> argsList = Arrays.asList(args);
-        for(CommandRoute route : routes) {
-            //skip invalid subcommands
-            String[] routeStarts = route.getStartsWith();
-            if(routeStarts.length != 0 && routeStarts.length <= argsList.size()) {
-                if(routeStarts.length > argsList.size()) {
-                    continue;
+        if(routes != null) {
+            List<String> argsList = Arrays.asList(args);
+            for(CommandRoute route : routes) {
+                //skip invalid subcommands
+                String[] routeStarts = route.getStartsWith();
+                if(routeStarts.length != 0 && routeStarts.length <= argsList.size()) {
+                    if(routeStarts.length > argsList.size()) {
+                        continue;
+                    }
+                    List<String> routeStartsList = Arrays.asList(routeStarts);
+                    List<String> argsSubList = argsList.subList(0, routeStarts.length);
+                    if(!routeStartsList.equals(argsSubList)) {
+                        continue;
+                    }
                 }
-                List<String> routeStartsList = Arrays.asList(routeStarts);
-                List<String> argsSubList = argsList.subList(0, routeStarts.length);
-                if(!routeStartsList.equals(argsSubList)) {
-                    continue;
+
+                //valid route to apply
+                appliedRoutes++;
+
+                //check permissions
+                String permission = route.getPermission();
+                if(null != permission && !sender.hasPermission(permission)) {
+                    sender.sendMessage(ChatColor.RED + "You do not have permission to run that command. (" + permission + ")");
+                    return true;
                 }
-            }
 
-            //valid route to apply
-            appliedRoutes++;
-
-            //check permissions
-            String permission = route.getPermission();
-            if(null != permission && !sender.hasPermission(permission)) {
-                sender.sendMessage(ChatColor.RED + "You do not have permission to run that command. (" + permission + ")");
+                //run the actual command
+                try {
+                    route.run(command, sender, args);
+                } catch(CommandInvocationException e) {
+                    e.printStackTrace();
+                }
                 return true;
             }
-
-            //run the actual command
-            try {
-                route.run(command, sender, args);
-            } catch(CommandInvocationException e) {
-                e.printStackTrace();
-            }
-            return true;
         }
 
         //if we did't know how to handle this command

--- a/src/main/java/com/publicuhc/pluginframework/routing/SubcommandLengthComparator.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/SubcommandLengthComparator.java
@@ -1,0 +1,45 @@
+/*
+ * SubcommandLengthComparator.java
+ *
+ * Copyright (c) 2014. Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * This file is part of PluginFramework.
+ *
+ * PluginFramework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PluginFramework is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PluginFramework.  If not, see <http ://www.gnu.org/licenses/>.
+ */
+
+package com.publicuhc.pluginframework.routing;
+
+import java.util.Comparator;
+
+class SubcommandLengthComparator implements Comparator<CommandRoute>
+{
+    @Override
+    public int compare(CommandRoute route1, CommandRoute route2)
+    {
+        int r1 = route1.getStartsWith().length;
+        int r2 = route2.getStartsWith().length;
+
+        if(r1 == r2)
+            return 0;
+
+        if(r1 > r2)
+            return -1;
+
+        if(r2 > r1)
+            return 1;
+
+        throw new IllegalStateException();
+    }
+}

--- a/src/test/java/com/publicuhc/pluginframework/routing/DefaultRouterTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/DefaultRouterTest.java
@@ -308,6 +308,57 @@ public class DefaultRouterTest
         verify(sender, times(1)).sendMessage(contains("Description"));
     }
 
+    @Test
+    public void test_run_subcommand_main_command() throws CommandParseException
+    {
+        SampleSubCommandClass sample = new SampleSubCommandClass();
+        router.registerCommands(sample, false);
+
+        assertThat(router.commands).hasSize(1);
+        assertThat(router.commands.get("testcommand")).hasSize(2);
+
+        CommandSender sender = mock(CommandSender.class);
+        Command command = Bukkit.getPluginCommand("testcommand");
+
+        router.onCommand(sender, command, "", new String[]{""});
+
+        assertThat(sample.testCommandRan).isTrue();
+        assertThat(sample.testSubCommandRan).isFalse();
+    }
+
+    @Test
+    public void test_run_subcommand_sub_command() throws CommandParseException
+    {
+        SampleSubCommandClass sample = new SampleSubCommandClass();
+        router.registerCommands(sample, false);
+
+        assertThat(router.commands).hasSize(1);
+        assertThat(router.commands.get("testcommand")).hasSize(2);
+
+        CommandSender sender = mock(CommandSender.class);
+        Command command = Bukkit.getPluginCommand("testcommand");
+
+        router.onCommand(sender, command, "", new String[]{"subcommand"});
+
+        assertThat(sample.testCommandRan).isFalse();
+        assertThat(sample.testSubCommandRan).isTrue();
+    }
+
+    @Test
+    public void test_run_root_command_with_no_route() throws CommandParseException
+    {
+        SampleMissingRootCommandClass sample = new SampleMissingRootCommandClass();
+        router.registerCommands(sample, false);
+
+        assertThat(router.commands).hasSize(1);
+        assertThat(router.commands.get("testcommand")).hasSize(1);
+
+        CommandSender sender = mock(CommandSender.class);
+        Command command = Bukkit.getPluginCommand("testcommand");
+
+        assertThat(router.onCommand(sender, command, "", new String[]{""})).isFalse();
+    }
+
     public class SampleCommandClass
     {
         public OptionSet lastOptionSet;
@@ -330,6 +381,31 @@ public class DefaultRouterTest
                     .withOptionalArg()
                     .ofType(Integer.class);
         }
+    }
+
+    public class SampleSubCommandClass
+    {
+        public boolean testCommandRan = false;
+        public boolean testSubCommandRan = false;
+
+        @CommandMethod(command = "testcommand")
+        public void testCommand(CommandRequest request)
+        {
+            testCommandRan = true;
+        }
+
+        @CommandMethod(command = "testcommand subcommand")
+        public void testSubCommand(CommandRequest request)
+        {
+            testSubCommandRan = true;
+        }
+    }
+
+    public class SampleMissingRootCommandClass
+    {
+        @CommandMethod(command = "testcommand subcommand")
+        public void testSubCommand(CommandRequest request)
+        {}
     }
 
     public class PermCommandClass

--- a/src/test/java/com/publicuhc/pluginframework/routing/DefaultRouterTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/DefaultRouterTest.java
@@ -75,7 +75,8 @@ public class DefaultRouterTest
         when(Bukkit.getPluginCommand("testcommand")).thenReturn(command);
     }
 
-    private void verifyRouteCorrect(CommandRoute route) throws Throwable {
+    private void verifyRoutesCorrect(List<CommandRoute> routes) throws Throwable {
+        CommandRoute route = routes.get(0);
         assertThat(route).isNotNull();
         assertThat(route.getCommandName()).isEqualTo("testcommand");
         assertThat(route.getProxy().getInstance()).isInstanceOf(ValidCommandClass.class);
@@ -107,8 +108,8 @@ public class DefaultRouterTest
         router.registerCommands(ValidCommandClass.class);
         assertThat(router.commands).hasSize(1);
 
-        CommandRoute route = router.commands.get("testcommand");
-        verifyRouteCorrect(route);
+        List<CommandRoute> route = router.commands.get("testcommand");
+        verifyRoutesCorrect(route);
 
         //it should create a child injector and use that to create the class
         verify(injector, times(1)).createChildInjector(listOfSize(0));
@@ -126,8 +127,8 @@ public class DefaultRouterTest
         router.registerCommands(ValidCommandClass.class, modules);
         assertThat(router.commands).hasSize(1);
 
-        CommandRoute route = router.commands.get("testcommand");
-        verifyRouteCorrect(route);
+        List<CommandRoute> route = router.commands.get("testcommand");
+        verifyRoutesCorrect(route);
 
         //it should create a child injector with given modules and use that to create the class
         verify(injector, times(1)).createChildInjector(modules);
@@ -143,8 +144,8 @@ public class DefaultRouterTest
         router.registerCommands(new ValidCommandClass(), true);
         assertThat(router.commands).hasSize(1);
 
-        CommandRoute route = router.commands.get("testcommand");
-        verifyRouteCorrect(route);
+        List<CommandRoute> route = router.commands.get("testcommand");
+        verifyRoutesCorrect(route);
 
         //it should create a child injector and use that to inject, not creating a class
         verify(injector, times(1)).createChildInjector(listOfSize(0));
@@ -161,8 +162,8 @@ public class DefaultRouterTest
         router.registerCommands(new ValidCommandClass(), true, modules);
         assertThat(router.commands).hasSize(1);
 
-        CommandRoute route = router.commands.get("testcommand");
-        verifyRouteCorrect(route);
+        List<CommandRoute> route = router.commands.get("testcommand");
+        verifyRoutesCorrect(route);
 
         //it should create a child injector and use that to inject, not creating a class
         verify(injector, times(1)).createChildInjector(modules);
@@ -179,8 +180,8 @@ public class DefaultRouterTest
         router.registerCommands(new ValidCommandClass(), false);
         assertThat(router.commands).hasSize(1);
 
-        CommandRoute route = router.commands.get("testcommand");
-        verifyRouteCorrect(route);
+        List<CommandRoute> route = router.commands.get("testcommand");
+        verifyRoutesCorrect(route);
 
         //it shouldn't do anything with the injector at all
         verifyNoMoreInteractions(injector);
@@ -193,8 +194,8 @@ public class DefaultRouterTest
         router.registerCommands(new ValidCommandClass(), false, listOfModuleMocks());
         assertThat(router.commands).hasSize(1);
 
-        CommandRoute route = router.commands.get("testcommand");
-        verifyRouteCorrect(route);
+        List<CommandRoute> route = router.commands.get("testcommand");
+        verifyRoutesCorrect(route);
 
         //it shouldn't do anything with the injector at all even though we gave it extra modules
         verifyNoMoreInteractions(injector);

--- a/src/test/java/com/publicuhc/pluginframework/routing/SubcommandLengthComparatorTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/SubcommandLengthComparatorTest.java
@@ -1,0 +1,73 @@
+/*
+ * SubcommandLengthComparator.java
+ *
+ * Copyright (c) 2014. Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * This file is part of PluginFramework.
+ *
+ * PluginFramework is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PluginFramework is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PluginFramework.  If not, see <http ://www.gnu.org/licenses/>.
+ */
+
+package com.publicuhc.pluginframework.routing;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+public class SubcommandLengthComparatorTest
+{
+    @Test
+    public void test_comparator()
+    {
+        CommandRoute routeLength0 = mock(CommandRoute.class);
+        when(routeLength0.getStartsWith()).thenReturn(new String[]{});
+
+        CommandRoute routeLength1 = mock(CommandRoute.class);
+        when(routeLength1.getStartsWith()).thenReturn(new String[]{""});
+
+        CommandRoute routeLength2 = mock(CommandRoute.class);
+        when(routeLength2.getStartsWith()).thenReturn(new String[]{"", ""});
+
+        SubcommandLengthComparator comparator = new SubcommandLengthComparator();
+
+        //test
+        assertThat(comparator.compare(routeLength0, routeLength1)).isEqualTo(1);
+        assertThat(comparator.compare(routeLength1, routeLength0)).isEqualTo(-1);
+        assertThat(comparator.compare(routeLength1, routeLength2)).isEqualTo(1);
+        assertThat(comparator.compare(routeLength2, routeLength1)).isEqualTo(-1);
+        assertThat(comparator.compare(routeLength2, routeLength0)).isEqualTo(-1);
+        assertThat(comparator.compare(routeLength0, routeLength2)).isEqualTo(1);
+        assertThat(comparator.compare(routeLength1, routeLength1)).isEqualTo(0);
+        assertThat(comparator.compare(routeLength2, routeLength2)).isEqualTo(0);
+        assertThat(comparator.compare(routeLength0, routeLength0)).isEqualTo(0);
+
+        List<CommandRoute> routeList = new ArrayList<CommandRoute>();
+        routeList.add(routeLength1);
+        routeList.add(routeLength2);
+        routeList.add(routeLength0);
+        routeList.add(routeLength1);
+
+        Collections.sort(routeList, comparator);
+        assertThat(routeList).containsExactly(routeLength2, routeLength1, routeLength1, routeLength0);
+    }
+}

--- a/src/test/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParserTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/parser/DefaultRoutingMethodParserTest.java
@@ -76,6 +76,12 @@ public class DefaultRoutingMethodParserTest
         return "TEST_STRING";
     }
 
+    @CommandMethod(command = "test subcommand system")
+    public String commandWithStartsWithRestriction(CommandRequest request)
+    {
+        return "TEST_STRING";
+    }
+
     public void commandWithoutAnnotation(CommandRequest request)
     {}
 
@@ -185,7 +191,8 @@ public class DefaultRoutingMethodParserTest
     }
 
     @Test
-    public void test_parse_permissions() throws NoSuchMethodException, CommandParseException {
+    public void test_parse_permissions() throws NoSuchMethodException, CommandParseException
+    {
         Method method = DefaultRoutingMethodParserTest.class.getDeclaredMethod("commandWithAnnotation", CommandRequest.class);
 
         CommandRoute route = parser.parseCommandMethodAnnotation(method, this);
@@ -215,8 +222,18 @@ public class DefaultRoutingMethodParserTest
         assertThat(proxy.invoke(mock(CommandRequest.class))).isEqualTo("TEST_STRING");
         assertThat(route.getOptionDetails().recognizedOptions()).containsKey("?");
         assertThat(route.getOptionDetails().recognizedOptions()).doesNotContainKey("t");
+        assertThat(route.getStartsWith()).isEmpty();
         //noinspection unchecked
         assertThat(route.getAllowedSenders()).containsExactly(CommandSender.class);
+    }
+
+    @Test
+    public void test_starts_with() throws Throwable
+    {
+        Method method = DefaultRoutingMethodParserTest.class.getDeclaredMethod("commandWithStartsWithRestriction", CommandRequest.class);
+        CommandRoute route = parser.parseCommandMethodAnnotation(method, this);
+
+        assertThat(route.getStartsWith()).containsExactly("subcommand", "system");
     }
 
     @Test


### PR DESCRIPTION
Supports subcommands using the @CommandMethod annotation

```
@CommandMethod(command = "feature")
...method....

@CommandMethod(command = "feature list")
...method...

@CommandMethod(command = "feature list something")
...method...
```

The above would register all 3 methods for the command `feature`. Will only ever run against the method with the largest applicable command. 

`/feature list` - Would choose `feature` and `feature list`. `feature list` has a longer argument list so it is chosen

`/feature list something` - Would choose all above methods, only `feature list something` triggers

`/feature something` - Only triggers `feature`.

If only subcommands are registered and no route command first it will attempt to send a message based on if you have set the default message for the command in the router, if no will return false and Bukkit will show the value from the plugin.yml
