### PR TITLE
Make no modules bind by default

### DIFF
--- a/src/main/java/com/publicuhc/pluginframework/FrameworkJavaPlugin.java
+++ b/src/main/java/com/publicuhc/pluginframework/FrameworkJavaPlugin.java
@@ -24,6 +24,9 @@ package com.publicuhc.pluginframework;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.publicuhc.pluginframework.configuration.ConfigurationModule;
+import com.publicuhc.pluginframework.routing.RoutingModule;
+import com.publicuhc.pluginframework.translate.TranslateModule;
 import org.bukkit.Server;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginLoader;
@@ -70,4 +73,14 @@ public abstract class FrameworkJavaPlugin extends JavaPlugin {
      * Setup the list of modules to load for the DI
      */
     protected abstract void initialModules(List<Module> modules);
+
+    protected List<Module> getDefaultModules()
+    {
+        List<Module> defaults = new ArrayList<Module>();
+        defaults.add(new PluginModule(this));
+        defaults.add(new TranslateModule());
+        defaults.add(new ConfigurationModule(this.getClassLoader()));
+        defaults.add(new RoutingModule());
+        return defaults;
+    }
 }

--- a/src/main/java/com/publicuhc/pluginframework/FrameworkJavaPlugin.java
+++ b/src/main/java/com/publicuhc/pluginframework/FrameworkJavaPlugin.java
@@ -23,19 +23,11 @@ package com.publicuhc.pluginframework;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.publicuhc.pluginframework.configuration.ConfigurationModule;
-import com.publicuhc.pluginframework.configuration.Configurator;
-import com.publicuhc.pluginframework.routing.Router;
-import com.publicuhc.pluginframework.routing.RoutingModule;
-import com.publicuhc.pluginframework.translate.Translate;
-import com.publicuhc.pluginframework.translate.TranslateModule;
 import org.bukkit.Server;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginLoader;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.mcstats.Metrics;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -43,35 +35,28 @@ import java.util.List;
 
 public abstract class FrameworkJavaPlugin extends JavaPlugin {
 
-    private Configurator m_configurator;
-    private Translate m_translate;
-    private Router m_router;
-    private Metrics m_metrics;
-
     /**
      * This method is intended for unit testing purposes. Its existence may be temporary.
      *
      * @see org.bukkit.plugin.java.JavaPlugin
      */
     @SuppressWarnings("deprecation")
-    protected FrameworkJavaPlugin(PluginLoader loader, Server server, PluginDescriptionFile pdf, File file1, File file2) {
+    protected FrameworkJavaPlugin(PluginLoader loader, Server server, PluginDescriptionFile pdf, File file1, File file2)
+    {
         super(loader, server, pdf, file1, file2);
     }
 
     public FrameworkJavaPlugin() {}
 
     @Override
-    public final void onEnable() {
+    public final void onEnable()
+    {
         List<AbstractModule> modules = initialModules();
         if (modules == null) {
             modules = new ArrayList<AbstractModule>();
         }
         modules.add(new PluginModule(this));
-        if (initUseDefaultBindings()) {
-            modules.add(new RoutingModule());
-            modules.add(new ConfigurationModule(this.getClassLoader()));
-            modules.add(new TranslateModule());
-        }
+
         Injector injector = Guice.createInjector(modules);
         injector.injectMembers(this);
         onFrameworkEnable();
@@ -80,97 +65,18 @@ public abstract class FrameworkJavaPlugin extends JavaPlugin {
     /**
      * Called when the framework is loaded
      */
-    protected void onFrameworkEnable() {
+    protected void onFrameworkEnable()
+    {
     }
 
     /**
-     * Return a list of extra modules to initialize DI with.
-     * Override this method to change the extra modules to load with.
+     * Return a list of modules to load for the DI
+     * Override this method to add modules to load with.
      *
      * @return the list of modules
      */
-    protected List<AbstractModule> initialModules() {
+    protected List<AbstractModule> initialModules()
+    {
         return null;
-    }
-
-    /**
-     * If returns true will include default modules on init.
-     * If false you must specify all the bindings for the framework
-     *
-     * @return whether to use the defaults or not
-     */
-    protected boolean initUseDefaultBindings() {
-        return true;
-    }
-
-    @Inject
-    private void setMetrics(Metrics metrics) {
-        m_metrics = metrics;
-    }
-
-    /**
-     * <b>ONLY USE THIS AFTER onEnable HAS BEEN CALLED. (onFrameworkEnable and later) otherwise it will return null</b>
-     *
-     * @return the plugin metrics
-     */
-    protected Metrics getMetrics() {
-        return m_metrics;
-    }
-
-    /**
-     * Set the router by injection
-     *
-     * @param router the router object
-     */
-    @Inject
-    private void setRouter(Router router) {
-        m_router = router;
-    }
-
-    /**
-     * Set the configurator by injection
-     *
-     * @param configurator the configurator object
-     */
-    @Inject
-    private void setConfigurator(Configurator configurator) {
-        m_configurator = configurator;
-    }
-
-    /**
-     * Set the translate by injection
-     *
-     * @param translate the translate object
-     */
-    @Inject
-    private void setTranslate(Translate translate) {
-        m_translate = translate;
-    }
-
-    /**
-     * <b>ONLY USE THIS AFTER onLoad HAS BEEN CALLED. (onFrameworkEnable and later) otherwise it will return null</b>
-     *
-     * @return the router object
-     */
-    protected Router getRouter() {
-        return m_router;
-    }
-
-    /**
-     * <b>ONLY USE THIS AFTER onLoad HAS BEEN CALLED. (onFrameworkEnable and later) otherwise it will return null</b>
-     *
-     * @return the configurator object
-     */
-    protected Configurator getConfigurator() {
-        return m_configurator;
-    }
-
-    /**
-     * <b>ONLY USE THIS AFTER onEnable HAS BEEN CALLED. (onFrameworkEnable and later) otherwise it will return null</b>
-     *
-     * @return the translate object
-     */
-    protected Translate getTranslate() {
-        return m_translate;
     }
 }

--- a/src/main/java/com/publicuhc/pluginframework/FrameworkJavaPlugin.java
+++ b/src/main/java/com/publicuhc/pluginframework/FrameworkJavaPlugin.java
@@ -21,9 +21,9 @@
 
 package com.publicuhc.pluginframework;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Module;
 import org.bukkit.Server;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginLoader;
@@ -51,11 +51,8 @@ public abstract class FrameworkJavaPlugin extends JavaPlugin {
     @Override
     public final void onEnable()
     {
-        List<AbstractModule> modules = initialModules();
-        if (modules == null) {
-            modules = new ArrayList<AbstractModule>();
-        }
-        modules.add(new PluginModule(this));
+        List<Module> modules = new ArrayList<Module>();
+        initialModules(modules);
 
         Injector injector = Guice.createInjector(modules);
         injector.injectMembers(this);
@@ -70,13 +67,7 @@ public abstract class FrameworkJavaPlugin extends JavaPlugin {
     }
 
     /**
-     * Return a list of modules to load for the DI
-     * Override this method to add modules to load with.
-     *
-     * @return the list of modules
+     * Setup the list of modules to load for the DI
      */
-    protected List<AbstractModule> initialModules()
-    {
-        return null;
-    }
+    protected abstract void initialModules(List<Module> modules);
 }

--- a/src/test/java/com/publicuhc/pluginframework/FrameworkJavaPluginTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/FrameworkJavaPluginTest.java
@@ -22,6 +22,7 @@
 package com.publicuhc.pluginframework;
 
 import com.google.inject.Module;
+import com.publicuhc.pluginframework.testplugins.TestPluginDefaultModules;
 import com.publicuhc.pluginframework.testplugins.TestPluginExtraModules;
 import com.publicuhc.pluginframework.testplugins.TestPluginNoModules;
 import com.publicuhc.pluginframework.testplugins.TestPluginReplaceModules;
@@ -47,7 +48,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class FrameworkJavaPluginTest {
 
     @Test
-    public void testUseNoModules() throws Exception
+    public void test_no_modules() throws Exception
     {
         PluginLoader loader = mock(PluginLoader.class);
         Server server = mock(Server.class);
@@ -58,6 +59,22 @@ public class FrameworkJavaPluginTest {
         when(server.getLogger()).thenReturn(logger);
 
         TestPluginNoModules plugin = new TestPluginNoModules(loader, server, pdf, file1, file1);
+        plugin.onLoad();
+        plugin.onEnable();
+    }
+
+    @Test
+    public void test_default_modules() throws Exception
+    {
+        PluginLoader loader = mock(PluginLoader.class);
+        Server server = mock(Server.class);
+        PluginDescriptionFile pdf = mock(PluginDescriptionFile.class);
+        File file1 = new File("target" + File.separator + "testdatafolder");
+
+        PluginLogger logger = mock(PluginLogger.class);
+        when(server.getLogger()).thenReturn(logger);
+
+        TestPluginDefaultModules plugin = new TestPluginDefaultModules(loader, server, pdf, file1, file1);
         assertThat(plugin.injectedPlugin).isNull();
 
         plugin.onLoad();
@@ -68,7 +85,8 @@ public class FrameworkJavaPluginTest {
     }
 
     @Test
-    public void testUseExtraModules() throws Exception {
+    public void test_extra_modules() throws Exception
+    {
         PluginLoader loader = mock(PluginLoader.class);
         Server server = mock(Server.class);
         PluginDescriptionFile pdf = mock(PluginDescriptionFile.class);
@@ -88,7 +106,8 @@ public class FrameworkJavaPluginTest {
     }
 
     @Test
-    public void testReplaceModules() throws Exception {
+    public void test_override_modules() throws Exception
+    {
         PluginLoader loader = mock(PluginLoader.class);
         Server server = mock(Server.class);
         PluginDescriptionFile pdf = mock(PluginDescriptionFile.class);
@@ -108,8 +127,9 @@ public class FrameworkJavaPluginTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testWrongClassloader() {
-        FrameworkJavaPlugin javaPlugin = new FrameworkJavaPlugin() {
+    public void test_wrong_classloader()
+    {
+        new FrameworkJavaPlugin() {
             @Override
             protected void initialModules(List<Module> modules)
             {}

--- a/src/test/java/com/publicuhc/pluginframework/FrameworkJavaPluginTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/FrameworkJavaPluginTest.java
@@ -21,12 +21,10 @@
 
 package com.publicuhc.pluginframework;
 
-import com.publicuhc.pluginframework.configuration.DefaultConfigurator;
-import com.publicuhc.pluginframework.routing.DefaultRouter;
-import com.publicuhc.pluginframework.testplugins.TestPluginDefaultModules;
+import com.google.inject.Module;
 import com.publicuhc.pluginframework.testplugins.TestPluginExtraModules;
+import com.publicuhc.pluginframework.testplugins.TestPluginNoModules;
 import com.publicuhc.pluginframework.testplugins.TestPluginReplaceModules;
-import com.publicuhc.pluginframework.translate.DefaultTranslate;
 import org.bukkit.Server;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginLoader;
@@ -38,6 +36,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -48,7 +47,8 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class FrameworkJavaPluginTest {
 
     @Test
-    public void testUseDefaultModules() throws Exception {
+    public void testUseNoModules() throws Exception
+    {
         PluginLoader loader = mock(PluginLoader.class);
         Server server = mock(Server.class);
         PluginDescriptionFile pdf = mock(PluginDescriptionFile.class);
@@ -57,23 +57,14 @@ public class FrameworkJavaPluginTest {
         PluginLogger logger = mock(PluginLogger.class);
         when(server.getLogger()).thenReturn(logger);
 
-        TestPluginDefaultModules plugin = new TestPluginDefaultModules(loader, server, pdf, file1, file1) { };
-
-        assertThat(plugin.getConfigurator()).isNull();
-        assertThat(plugin.getRouter()).isNull();
-        assertThat(plugin.getTranslate()).isNull();
+        TestPluginNoModules plugin = new TestPluginNoModules(loader, server, pdf, file1, file1);
+        assertThat(plugin.injectedPlugin).isNull();
 
         plugin.onLoad();
-
-        assertThat(plugin.getConfigurator()).isNull();
-        assertThat(plugin.getRouter()).isNull();
-        assertThat(plugin.getTranslate()).isNull();
+        assertThat(plugin.injectedPlugin).isNull();
 
         plugin.onEnable();
-
-        assertThat(plugin.getConfigurator()).isInstanceOf(DefaultConfigurator.class);
-        assertThat(plugin.getTranslate()).isInstanceOf(DefaultTranslate.class);
-        assertThat(plugin.getRouter()).isInstanceOf(DefaultRouter.class);
+        assertThat(plugin.injectedPlugin).isSameAs(plugin);
     }
 
     @Test
@@ -87,27 +78,12 @@ public class FrameworkJavaPluginTest {
         when(server.getLogger()).thenReturn(logger);
 
         TestPluginExtraModules plugin = new TestPluginExtraModules(loader, server, pdf, file1, file1);
-
-        assertThat(plugin.getConfigurator()).isNull();
-        assertThat(plugin.getRouter()).isNull();
-        assertThat(plugin.getTranslate()).isNull();
-
         assertThat(plugin.i).isNull();
 
         plugin.onLoad();
-
-        assertThat(plugin.getConfigurator()).isNull();
-        assertThat(plugin.getRouter()).isNull();
-        assertThat(plugin.getTranslate()).isNull();
-
         assertThat(plugin.i).isNull();
 
         plugin.onEnable();
-
-        assertThat(plugin.getConfigurator()).isInstanceOf(DefaultConfigurator.class);
-        assertThat(plugin.getTranslate()).isInstanceOf(DefaultTranslate.class);
-        assertThat(plugin.getRouter()).isInstanceOf(DefaultRouter.class);
-
         assertThat(plugin.i).isInstanceOf(TestPluginExtraModules.TestConcrete.class);
     }
 
@@ -122,28 +98,21 @@ public class FrameworkJavaPluginTest {
         when(server.getLogger()).thenReturn(logger);
 
         TestPluginReplaceModules plugin = new TestPluginReplaceModules(loader, server, pdf, file1, file1);
-
-        assertThat(plugin.getConfigurator()).isNull();
-        assertThat(plugin.getRouter()).isNull();
-        assertThat(plugin.getTranslate()).isNull();
-        assertThat(plugin.parser).isNull();
+        assertThat(plugin.logger).isNull();
 
         plugin.onLoad();
-
-        assertThat(plugin.getConfigurator()).isNull();
-        assertThat(plugin.getRouter()).isNull();
-        assertThat(plugin.getTranslate()).isNull();
-        assertThat(plugin.parser).isNull();
+        assertThat(plugin.logger).isNull();
 
         plugin.onEnable();
-
-        assertThat(plugin.getConfigurator()).isInstanceOf(TestPluginReplaceModules.TestConcreteConfigurator.class);
-        assertThat(plugin.getTranslate()).isInstanceOf(TestPluginReplaceModules.TestConcreteTranslate.class);
-        assertThat(plugin.getRouter()).isInstanceOf(TestPluginReplaceModules.TestConcreteRouter.class);
+        assertThat(plugin.logger).isInstanceOf(TestPluginReplaceModules.TestPluginLogger.class);
     }
 
     @Test(expected = IllegalStateException.class)
     public void testWrongClassloader() {
-        FrameworkJavaPlugin javaPlugin = new FrameworkJavaPlugin() { };
+        FrameworkJavaPlugin javaPlugin = new FrameworkJavaPlugin() {
+            @Override
+            protected void initialModules(List<Module> modules)
+            {}
+        };
     }
 }

--- a/src/test/java/com/publicuhc/pluginframework/testplugins/TestPluginDefaultModules.java
+++ b/src/test/java/com/publicuhc/pluginframework/testplugins/TestPluginDefaultModules.java
@@ -21,28 +21,40 @@
 
 package com.publicuhc.pluginframework.testplugins;
 
+import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.publicuhc.pluginframework.FrameworkJavaPlugin;
 import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginLoader;
 
 import java.io.File;
 import java.util.List;
 
-public class TestPluginNoModules extends FrameworkJavaPlugin {
+public class TestPluginDefaultModules extends FrameworkJavaPlugin {
+
+    public Plugin injectedPlugin;
 
     /**
      * This method is intended for unit testing purposes. Its existence may be temporary.
      *
      * @see org.bukkit.plugin.java.JavaPlugin
      */
-    public TestPluginNoModules(PluginLoader loader, Server server, PluginDescriptionFile pdf, File file1, File file2)
+    public TestPluginDefaultModules(PluginLoader loader, Server server, PluginDescriptionFile pdf, File file1, File file2)
     {
         super(loader, server, pdf, file1, file2);
     }
 
     @Override
     protected void initialModules(List<Module> modules)
-    {}
+    {
+        modules.addAll(getDefaultModules());
+    }
+
+    @Inject
+    public void setInjectedPlugin(Plugin plugin)
+    {
+        this.injectedPlugin = plugin;
+    }
 }

--- a/src/test/java/com/publicuhc/pluginframework/testplugins/TestPluginExtraModules.java
+++ b/src/test/java/com/publicuhc/pluginframework/testplugins/TestPluginExtraModules.java
@@ -23,13 +23,14 @@ package com.publicuhc.pluginframework.testplugins;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
+import com.google.inject.Module;
 import com.publicuhc.pluginframework.FrameworkJavaPlugin;
+import com.publicuhc.pluginframework.PluginModule;
 import org.bukkit.Server;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginLoader;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 
 public class TestPluginExtraModules extends FrameworkJavaPlugin {
@@ -39,20 +40,14 @@ public class TestPluginExtraModules extends FrameworkJavaPlugin {
      *
      * @see org.bukkit.plugin.java.JavaPlugin
      */
-    public TestPluginExtraModules(PluginLoader loader, Server server, PluginDescriptionFile pdf, File file1, File file2) {
+    public TestPluginExtraModules(PluginLoader loader, Server server, PluginDescriptionFile pdf, File file1, File file2)
+    {
         super(loader, server, pdf, file1, file2);
     }
 
-    public TestInterface i;
-
-    @Inject
-    public void setTest(TestInterface i) {
-        this.i = i;
-    }
-
     @Override
-    public List<AbstractModule> initialModules() {
-        List<AbstractModule> modules = new ArrayList<AbstractModule>();
+    protected void initialModules(List<Module> modules)
+    {
         AbstractModule module = new AbstractModule() {
             @Override
             protected void configure() {
@@ -60,10 +55,20 @@ public class TestPluginExtraModules extends FrameworkJavaPlugin {
             }
         };
         modules.add(module);
-        return modules;
+        modules.add(new PluginModule(this));
     }
 
-    public static interface TestInterface { }
+    public TestInterface i;
 
-    public static class TestConcrete implements TestInterface { }
+    @Inject
+    public void setTest(TestInterface i)
+    {
+        this.i = i;
+    }
+
+    public static interface TestInterface
+    {}
+
+    public static class TestConcrete implements TestInterface
+    {}
 }

--- a/src/test/java/com/publicuhc/pluginframework/testplugins/TestPluginNoModules.java
+++ b/src/test/java/com/publicuhc/pluginframework/testplugins/TestPluginNoModules.java
@@ -21,20 +21,41 @@
 
 package com.publicuhc.pluginframework.testplugins;
 
+import com.google.inject.Inject;
+import com.google.inject.Module;
 import com.publicuhc.pluginframework.FrameworkJavaPlugin;
+import com.publicuhc.pluginframework.PluginModule;
 import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginLoader;
 
 import java.io.File;
+import java.util.List;
 
-public class TestPluginDefaultModules extends FrameworkJavaPlugin {
+public class TestPluginNoModules extends FrameworkJavaPlugin {
+
+    public Plugin injectedPlugin;
+
     /**
      * This method is intended for unit testing purposes. Its existence may be temporary.
      *
      * @see org.bukkit.plugin.java.JavaPlugin
      */
-    public TestPluginDefaultModules(PluginLoader loader, Server server, PluginDescriptionFile pdf, File file1, File file2) {
+    public TestPluginNoModules(PluginLoader loader, Server server, PluginDescriptionFile pdf, File file1, File file2)
+    {
         super(loader, server, pdf, file1, file2);
+    }
+
+    @Override
+    protected void initialModules(List<Module> modules)
+    {
+        modules.add(new PluginModule(this));
+    }
+
+    @Inject
+    public void setInjectedPlugin(Plugin plugin)
+    {
+        this.injectedPlugin = plugin;
     }
 }


### PR DESCRIPTION
Makes no modules bind by default. Allows the user to override base modules that was impossible otherwise. Cleans up the base plugin class
