### PR TITLE
Quoted arguments

### DIFF
--- a/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
+++ b/src/main/java/com/publicuhc/pluginframework/routing/DefaultCommandRoute.java
@@ -86,25 +86,28 @@ public class DefaultCommandRoute implements CommandRoute
         }
     }
 
-    private String[] fixQuoted(String[] args)
+    protected String[] fixQuoted(String[] args)
     {
         List<String> fixed = new ArrayList<String>();
         StringBuilder builder = new StringBuilder();
         boolean insideQuotes = false;
         for (String arg : args) {
-            if (arg.startsWith("\"")) {
+            if(!insideQuotes && arg.startsWith("\"")) {
                 insideQuotes = true;
+                arg = arg.substring(1);
+            }
+            if (insideQuotes && arg.endsWith("\"")) {
+                insideQuotes = false;
+                arg = arg.substring(0, arg.length() - 1);
+                builder.append(" ").append(arg);
+                //remove the extra " " at the start of the arg
+                arg = builder.toString().substring(1);
+                builder = new StringBuilder();
             }
             if (insideQuotes) {
-                //add turn '" arg' into ' arg'
-                builder.append(" ").append(arg.substring(1));
-            }
-            if (arg.endsWith("\"")) {
-                insideQuotes = false;
-                builder.append(" ").append(arg.substring(0, arg.length() - 1));
-                //remove the extra " " at the start of the arg
-                fixed.add(builder.toString().substring(1));
-                builder = new StringBuilder();
+                builder.append(" ").append(arg);
+            } else {
+                fixed.add(arg);
             }
         }
 

--- a/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
+++ b/src/test/java/com/publicuhc/pluginframework/routing/DefaultCommandRouteTest.java
@@ -43,6 +43,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -231,5 +232,47 @@ public class DefaultCommandRouteTest
             verify(parser, times(1)).parse(args);
             verify(proxy, times(1)).invoke(set, sender);
         }
+    }
+
+    @Test
+    public void test_fix_quotes()
+    {
+        DefaultCommandRoute route = new DefaultCommandRoute("test", proxy, parser, new String[]{}, help, defaultTesters);
+
+        String[] testArgs = new String[]{
+                "separate",
+                "args",
+                "\"this",
+                "is",
+                "in",
+                "one",
+                "arg\"",
+                "outer",
+                "stuff"
+        };
+
+        String[] fixed = route.fixQuoted(testArgs);
+        assertThat(fixed).containsExactly("separate", "args", "this is in one arg", "outer", "stuff");
+
+        testArgs = new String[]{
+                "th\"ese",
+                "arg\"s",
+                "shouldn't\"",
+                "be",
+                "affected"
+        };
+        fixed = route.fixQuoted(testArgs);
+        assertThat(fixed).containsExactly("th\"ese", "arg\"s", "shouldn't\"", "be", "affected");
+
+        testArgs = new String[] {
+                "\"these",
+                "args",
+                "are",
+                "all",
+                "in",
+                "one"
+        };
+        fixed = route.fixQuoted(testArgs);
+        assertThat(fixed).containsExactly("these args are all in one");
     }
 }


### PR DESCRIPTION
Filters the input args to combine quoted args.

Args are counted as together based on:
- The first one starts with a "
- The last one ends with a " or the end of the arguments is reached.

Examples:

`arg1 arg2 "These args are counted as one" arg4 arg5` -> `'arg1', 'arg2', 'These args are counted as one', 'arg4', 'arg5'`

`arg1 "These args are counted` -> `'arg1', 'These args are counted'`

`arg1 te"st arg3` -> `'arg1', 'te"st', 'arg3'`

`arg1 "sub "starters are not counted" argsomething` -> `'arg1', 'sub "starters are not counted', 'argsomething'`

`arg extra" enders are ignored` -> `'arg', 'extra"', 'enders', 'are', 'ignored'`
